### PR TITLE
Check the io_uring_probe result

### DIFF
--- a/probe.c
+++ b/probe.c
@@ -47,6 +47,10 @@ int main() {
     printf("You are running kernel version: %s\n", u.release);
     printf("This program won't work on kernel versions earlier than 5.6\n");
     struct io_uring_probe *probe = io_uring_get_probe();
+    if (probe == NULL) {
+        perror("Error probing io_uring");
+        exit(1);
+    }
     printf("Report of your kernel's list of supported io_uring operations:\n");
     for (char i = 0; i < IORING_OP_LAST; i++ ) {
         printf("%s: ", op_strs[i]);


### PR DESCRIPTION
On kernels without io_uring, io_uring_probe returns NULL, leading to a
segfault in probe. Check the result instead, and print the appropriate
error message.

Signed-off-by: Stephen Kitt <steve@sk2.org>