### PR TITLE
Fix bug when checking kernel versions

### DIFF
--- a/webserver_liburing.c
+++ b/webserver_liburing.c
@@ -91,7 +91,7 @@ int check_kernel_version() {
     }
     printf("Minimum kernel version required is: %d.%d\n",
             MIN_KERNEL_VERSION, MIN_MAJOR_VERSION);
-    if (ver[0] >= MIN_KERNEL_VERSION && ver[1] >= MIN_MAJOR_VERSION ) {
+    if (ver[0] >= MIN_KERNEL_VERSION || ver[0] == MIN_KERNEL_VERSION && ver[1] >= MIN_MAJOR_VERSION ) {
         printf("Your kernel version is: %ld.%ld\n", ver[0], ver[1]);
         return 0;
     }


### PR DESCRIPTION
Building on the 6.0 kernel failed on the version check because MIN_MAJOR_VERSION was less than 5.