### PR TITLE
probe.c: check returned pointer from io_uring_get_probe

### DIFF
--- a/probe.c
+++ b/probe.c
@@ -47,6 +47,12 @@ int main() {
     printf("You are running kernel version: %s\n", u.release);
     printf("This program won't work on kernel versions earlier than 5.6\n");
     struct io_uring_probe *probe = io_uring_get_probe();
+    if (probe == NULL) 
+    {
+	    printf("io_uring_get_probe failed.\n");
+	    return 1; 
+
+    }
     printf("Report of your kernel's list of supported io_uring operations:\n");
     for (char i = 0; i < IORING_OP_LAST; i++ ) {
         printf("%s: ", op_strs[i]);


### PR DESCRIPTION
If I run probe on Alma Linux 9.7 with 5.14 kernel I get:
```
./probe
You are running kernel version: 5.14.0-611.13.1.el9_7.x86_64
This program won't work on kernel versions earlier than 5.6
Report of your kernel's list of supported io_uring operations:
Segmentation fault (core dumped)
```

With this PR I get:

```
./probe
You are running kernel version: 5.14.0-611.13.1.el9_7.x86_64
This program won't work on kernel versions earlier than 5.6
io_uring_get_probe failed.
```

